### PR TITLE
Fix load balancer request helper and stabilize tests

### DIFF
--- a/loadbalancer/utils/send_request.go
+++ b/loadbalancer/utils/send_request.go
@@ -1,19 +1,24 @@
 package utils
 
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
 
-func send_request(url, request){
-
-	resp, err := http.Post(url, "application/json", request)
-	//Handle Error
+// SendRequest posts the given request body to the provided URL and returns the
+// response body. The caller is responsible for interpreting the returned data.
+func SendRequest(url string, body io.Reader) ([]byte, error) {
+	resp, err := http.Post(url, "application/json", body)
 	if err != nil {
-		log.Fatalf("An Error Occured %v", err)
+		return nil, fmt.Errorf("failed to send request: %w", err)
 	}
 	defer resp.Body.Close()
-	//Read the response body
-	body, err := ioutil.ReadAll(resp.Body)
+
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatalln(err)
+		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
-	sb := string(body)
-	return body
+
+	return respBody, nil
 }

--- a/tests/integration/login_test.go
+++ b/tests/integration/login_test.go
@@ -1,0 +1,10 @@
+package integration
+
+import "testing"
+
+// TestLogin is a placeholder for integration tests of the login flow. The
+// current repository does not provide a running server for integration tests,
+// so this test is skipped.
+func TestLogin(t *testing.T) {
+	t.Skip("integration test not implemented")
+}


### PR DESCRIPTION
## Summary
- implement `SendRequest` helper for load balancer utilities with proper error handling
- add placeholder integration test to prevent build failures

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a0bd474f4483338faed8c48997bcb9